### PR TITLE
[Bugfix] Fixed issue with Elements getting unintentionally created on mousedowns

### DIFF
--- a/App/CanvasElements/Events.js
+++ b/App/CanvasElements/Events.js
@@ -14,16 +14,24 @@ import { draw } from './Main/Draw.js'; // TODO: will be removed
  */
 
 $(document).mousedown(function(e) {
-  if (cache.press && tool.type != 'selection') { // while the user is mouse pressing
-      newSVG.create(tool.type);  
+  if (cache.press && tool.type != 'selection') { // when the user has an element tool selected
+      newSVG.creating = true; // indicates that the user mouse-pressed down and might create an element by dragging
   }
 }).mousemove(function(e) {
 	// cache.stop points to the current cursor position on user's mousedown,
 	// and it also points to the last position the cursor was in before the mouseup event
 	cache.stop = [e.clientX,e.clientY];
-    if (cache.press && tool.type != 'selection') { // while the user is mouse pressing
+
+    if (newSVG.creating) { // checks if the user mouse-pressed down with an element creation tool
+      newSVG.creating = false;
+
+      newSVG.create(tool.type);
+    }
+
+    if (cache.press && tool.type != 'selection') {
       editSVG.update(tool.type);
     }
+
     if (pressed.handle) {
       svg.resize();
     }
@@ -33,10 +41,7 @@ $(document).mousedown(function(e) {
 });
 
 $(document).mouseup(function() {
-  if (newSVG.created) {
-    draw.selection(cache.ele);
-    newSVG.created = false;
-  }
+  draw.selection(cache.ele);
   
   cache.press = false;
   pressed.handle = false;

--- a/App/CanvasElements/Main/newSVG.js
+++ b/App/CanvasElements/Main/newSVG.js
@@ -11,25 +11,20 @@ var newSVG = {
 	numID: 0, // this will increment each time an element is created in order to give each element a unique ID
 	id: '#0',
 
-	created: false,
+	creating: false, // indicates that the user moused-down and might drag to create an element
 	finished: false,
 
 	// TODO: Split up events (mousedown from mouse dragging) so that the check for this.created is not needed
 	create(type, id) {
-		// this checks that the element was not created yet before appending, so this first if block runs once
-		if (this.created == false) { // this if block prevents the element from being appended/created twice
-			if (!id) {
-				id = this.numID;
-				this.numID++;
-			}
-			// the below code simply append to the HTML Document
-			$('#editor').html($('#editor').html() + '<' + type + ' id=' + id + '/>');
-			this.id = '#' + id;
-			cache.ele = id;
-			
-			this.created = true;
-			this.finished = false;
+		
+		if (!id) {
+			id = this.numID;
+			this.numID++;
 		}
+		// the below code simply append to the HTML Document
+		$('#editor').html($('#editor').html() + '<' + type + ' id=' + id + '/>');
+		this.id = '#' + id;
+		cache.ele = id;
 
 		//** run the test on the specific type of element created, make sure attributes valid */
 		test[type]; 


### PR DESCRIPTION
Changed Events in order to fix bug with elements getting unintentionally created when the user mousedown clicks once while using an element creation tool.

Simplified the newSVG create function by removing an if block, since that detail could be better dealt with in the Events.